### PR TITLE
Removes plugin for french translation

### DIFF
--- a/sonarqube/Dockerfile
+++ b/sonarqube/Dockerfile
@@ -7,7 +7,6 @@ RUN wget -nv "https://github.com/checkstyle/sonar-checkstyle/releases/download/9
 	wget -nv "https://github.com/sbaudoin/sonar-yaml/releases/download/v1.7.0/sonar-yaml-plugin-1.7.0.jar" && \
 	wget -nv "https://github.com/kwoding/sonar-webdriver-plugin/releases/download/sonar-webdriver-plugin-1.0.10/sonar-webdriver-plugin-1.0.10.jar" && \
 	wget -nv "https://github.com/sbaudoin/sonar-shellcheck/releases/download/v2.5.0/sonar-shellcheck-plugin-2.5.0.jar" && \
-	wget -nv "https://github.com/ZoeThivet/sonar-l10n-fr/releases/download/1.15.1/sonar-l10n-fr-plugin-1.15.1.jar"  && \
 	wget -nv "https://github.com/spotbugs/sonar-findbugs/releases/download/4.0.5/sonar-findbugs-plugin-4.0.5.jar" && \
 	wget -nv "https://github.com/edwinyangzh/sonar-java-i18n-checks/releases/download/v0.1.0/java-i18n-rules-0.1.0.jar" && \
 	wget -nv "https://github.com/dependency-check/dependency-check-sonar-plugin/releases/download/2.0.8/sonar-dependency-check-plugin-2.0.8.jar" && \


### PR DESCRIPTION
Le plugin sonar-l10n-fr n'est pas compatible avec la version 9 de SonarQube. 
Il provoque un chargement infini de l’interface web.